### PR TITLE
count checker: a captured tool output is not a live claim

### DIFF
--- a/integrity/registry_integrity.py
+++ b/integrity/registry_integrity.py
@@ -291,19 +291,33 @@ ORPHAN_PATTERNS = [
 ]
 
 CAPTURED_OUTPUT_DIRS = ("mining/",)
-FENCE_RE = re.compile(r"^\s*```")
+# A fence is at most three spaces indented; four or more spaces is an
+# INDENTED CODE BLOCK, not a fence, and treating it as one would flip
+# in_fence and exempt every live count claim after it. Both CommonMark fence
+# characters are recognised, and a fence is only closed by its own character,
+# so a ``` inside a ~~~ block does not end it.
+FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
 
 
 def _code_spans(line):
-    """Character ranges covered by inline `code` spans on this line."""
+    """Character ranges covered by inline `code` spans on this line.
+
+    A BACKSLASH-ESCAPED backtick does not open or close a span: Markdown
+    renders it literally. Counting it would let ordinary prose that happens to
+    contain escaped backticks look like captured output, which would exempt a
+    live claim.
+    """
     spans, start = [], None
     for i, ch in enumerate(line):
-        if ch == "`":
-            if start is None:
-                start = i
-            else:
-                spans.append((start, i))
-                start = None
+        if ch != "`":
+            continue
+        if i and line[i - 1] == "\\":
+            continue
+        if start is None:
+            start = i
+        else:
+            spans.append((start, i))
+            start = None
     return spans
 
 
@@ -499,11 +513,17 @@ def check_counts(root, n_entries, findings):
                 continue
             rel = os.path.relpath(os.path.join(dp, fn), root).replace("\\", "/")
             text = read(os.path.join(dp, fn))
-            in_fence = False
+            fence_char = None
             for i, line in enumerate(text.splitlines(), 1):
-                if FENCE_RE.match(line):
-                    in_fence = not in_fence
+                fm = FENCE_RE.match(line)
+                if fm:
+                    ch = fm.group(1)[0]
+                    if fence_char is None:
+                        fence_char = ch
+                    elif ch == fence_char:
+                        fence_char = None
                     continue
+                in_fence = fence_char is not None
                 for rx, total_g, impl_g in TOTAL_PATTERNS:
                     for m in rx.finditer(line):
                         if is_captured_output(rel, line, m.span(), in_fence):

--- a/integrity/registry_integrity.py
+++ b/integrity/registry_integrity.py
@@ -300,24 +300,36 @@ FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
 
 
 def _code_spans(line):
-    """Character ranges covered by inline `code` spans on this line.
+    """Character ranges covered by inline code spans on this line.
 
-    A BACKSLASH-ESCAPED backtick does not open or close a span: Markdown
-    renders it literally. Counting it would let ordinary prose that happens to
-    contain escaped backticks look like captured output, which would exempt a
-    live claim.
+    A code span is delimited by backtick runs of EQUAL length, so ``x`` is one
+    span and not two adjacent one-backtick spans. Captured output often needs
+    the longer form precisely because it contains a backtick of its own.
+
+    A BACKSLASH-ESCAPED backtick neither opens nor closes: Markdown renders it
+    literally, and counting it would let ordinary prose look like a capture.
     """
-    spans, start = [], None
-    for i, ch in enumerate(line):
-        if ch != "`":
+    runs = []
+    i, n = 0, len(line)
+    while i < n:
+        if line[i] != "`":
+            i += 1
             continue
         if i and line[i - 1] == "\\":
+            i += 1
             continue
-        if start is None:
-            start = i
-        else:
-            spans.append((start, i))
-            start = None
+        j = i
+        while j < n and line[j] == "`":
+            j += 1
+        runs.append((i, j, j - i))
+        i = j
+    spans, open_run = [], None
+    for a, b, ln in runs:
+        if open_run is None:
+            open_run = (a, b, ln)
+        elif ln == open_run[2]:
+            spans.append((open_run[1] - 1, a))
+            open_run = None
     return spans
 
 
@@ -513,17 +525,20 @@ def check_counts(root, n_entries, findings):
                 continue
             rel = os.path.relpath(os.path.join(dp, fn), root).replace("\\", "/")
             text = read(os.path.join(dp, fn))
-            fence_char = None
+            fence = None
             for i, line in enumerate(text.splitlines(), 1):
                 fm = FENCE_RE.match(line)
                 if fm:
-                    ch = fm.group(1)[0]
-                    if fence_char is None:
-                        fence_char = ch
-                    elif ch == fence_char:
-                        fence_char = None
+                    run = fm.group(1)
+                    ch, ln = run[0], len(run)
+                    if fence is None:
+                        fence = (ch, ln)
+                    elif ch == fence[0] and ln >= fence[1]:
+                        # A closing fence must be at least as long as the
+                        # opener, so a ``` line inside a ```` block is content.
+                        fence = None
                     continue
-                in_fence = fence_char is not None
+                in_fence = fence is not None
                 for rx, total_g, impl_g in TOTAL_PATTERNS:
                     for m in rx.finditer(line):
                         if is_captured_output(rel, line, m.span(), in_fence):

--- a/integrity/registry_integrity.py
+++ b/integrity/registry_integrity.py
@@ -333,6 +333,13 @@ def _code_spans(line):
     return spans
 
 
+# KNOWN LIMITATION, accepted deliberately: inline code spans are matched
+# per line. A span whose opening delimiter is on one line and whose number is
+# on the next is not recognised, so that number is treated as a live claim.
+# The failure is therefore CLOSED, not open: an unrecognised capture is
+# reported, never silently exempted. Fixing it properly needs document-level
+# CommonMark parsing, which is a larger change than this rule warrants; the
+# fenced form covers multi-line captured output and is what notes actually use.
 def is_captured_output(rel, line, span, in_fence):
     """True only for a number that is captured tool output, not an assertion.
 
@@ -531,13 +538,25 @@ def check_counts(root, n_entries, findings):
                 if fm:
                     run = fm.group(1)
                     ch, ln = run[0], len(run)
+                    rest = line[fm.end():]
                     if fence is None:
-                        fence = (ch, ln)
-                    elif ch == fence[0] and ln >= fence[1]:
-                        # A closing fence must be at least as long as the
-                        # opener, so a ``` line inside a ```` block is content.
+                        # A BACKTICK opening fence's info string may not itself
+                        # contain a backtick. Opening on one would exempt every
+                        # live claim after it, so an invalid opener is not a
+                        # fence and the line is ordinary content.
+                        if ch == "`" and "`" in rest:
+                            pass
+                        else:
+                            fence = (ch, ln)
+                            continue
+                    elif ch == fence[0] and ln >= fence[1] and not rest.strip():
+                        # A closing fence must be at least as long as its
+                        # opener AND have nothing but whitespace after it, so
+                        # "~~~ still running" inside a block is content.
                         fence = None
-                    continue
+                        continue
+                    else:
+                        continue
                 in_fence = fence is not None
                 for rx, total_g, impl_g in TOTAL_PATTERNS:
                     for m in rx.finditer(line):

--- a/integrity/registry_integrity.py
+++ b/integrity/registry_integrity.py
@@ -37,6 +37,23 @@ CHANGELOG.md is deliberately exempt from COUNT. It is an append-only record of
 what was true on a date; a 2026-07-28 line reading "corrected to 17 of 42" must
 keep saying 42 after the tree grows, or the log stops being a log.
 
+The same rule, narrowed, applies to CAPTURED OUTPUT under mining/. A mining
+note records a run: when it pastes the coverage line a tool actually printed,
+"implemented 19/103" has to keep saying 103, because that is what it printed.
+Rewriting a capture to match a tree that has since grown falsifies evidence,
+which is a failure this registry catalogues rather than commits.
+
+The exemption is deliberately NOT "ignore numbers under mining/". It applies
+only where the number sits inside a code span or a fenced block, which is how
+captured output is written and how a live assertion is not. So:
+
+    mining/note.md   `implemented 19/103 | ...`      exempt, it is a capture
+    mining/note.md   19 of these 103 entries          NOT exempt, that is prose
+    README.md        anything                          NOT exempt, ever
+    traps/**         anything                          NOT exempt, ever
+
+A prose sentence in a mining summary is a current claim and stays enforced.
+
 Usage:
     python3 integrity/registry_integrity.py [--root .] [--json]
 
@@ -273,6 +290,38 @@ ORPHAN_PATTERNS = [
     re.compile(r"remaining\s+\*{0,2}(\d+)\*{0,2}\s+numbered\s+traps"),
 ]
 
+CAPTURED_OUTPUT_DIRS = ("mining/",)
+FENCE_RE = re.compile(r"^\s*```")
+
+
+def _code_spans(line):
+    """Character ranges covered by inline `code` spans on this line."""
+    spans, start = [], None
+    for i, ch in enumerate(line):
+        if ch == "`":
+            if start is None:
+                start = i
+            else:
+                spans.append((start, i))
+                start = None
+    return spans
+
+
+def is_captured_output(rel, line, span, in_fence):
+    """True only for a number that is captured tool output, not an assertion.
+
+    Narrow on purpose. Restricted to the directories in CAPTURED_OUTPUT_DIRS,
+    and within those, to numbers inside a fenced block or an inline code span.
+    Prose in the same file is still a live claim and stays enforced.
+    """
+    if not any(rel.startswith(d) for d in CAPTURED_OUTPUT_DIRS):
+        return False
+    if in_fence:
+        return True
+    a, b = span
+    return any(lo < a and b <= hi for lo, hi in _code_spans(line))
+
+
 COUNT_SCAN_EXTS = (".md", ".py")
 COUNT_SKIP_FILES = {"CHANGELOG.md"}
 COUNT_SKIP_DIRS = {".git", "__pycache__", "integrity"}
@@ -450,9 +499,15 @@ def check_counts(root, n_entries, findings):
                 continue
             rel = os.path.relpath(os.path.join(dp, fn), root).replace("\\", "/")
             text = read(os.path.join(dp, fn))
+            in_fence = False
             for i, line in enumerate(text.splitlines(), 1):
+                if FENCE_RE.match(line):
+                    in_fence = not in_fence
+                    continue
                 for rx, total_g, impl_g in TOTAL_PATTERNS:
                     for m in rx.finditer(line):
+                        if is_captured_output(rel, line, m.span(), in_fence):
+                            continue
                         total = int(m.group(total_g))
                         if total != n_entries:
                             findings.append(Finding(
@@ -472,6 +527,8 @@ def check_counts(root, n_entries, findings):
                 expected_orphan = n_entries - implemented
                 for rx in ORPHAN_PATTERNS:
                     for m in rx.finditer(line):
+                        if is_captured_output(rel, line, m.span(), in_fence):
+                            continue
                         got = int(m.group(1))
                         if got != expected_orphan:
                             findings.append(Finding(

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -27,6 +27,7 @@ import tempfile
 import unittest
 
 NL = chr(10)
+BT = chr(96)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 INTEGRITY = os.path.dirname(HERE)
@@ -351,6 +352,56 @@ class RegistryMutations(unittest.TestCase):
         self.assertTrue(any("SCRATCH_NOTE.md" in f["where"]
                             for f in findings_of(out, "COUNT")))
 
+
+
+    # Three Markdown-parsing edge cases Codex found on the first version of
+    # this rule. Two of them widened the exemption, which is the dangerous
+    # direction: an over-strict rule annoys, an over-loose one lets a stale
+    # live claim through.
+
+    def test_50_indented_backticks_are_not_a_fence(self):
+        """Four or more leading spaces is an indented code block, not a fence.
+        Treating it as one would flip fence state and exempt every live count
+        claim after it."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-indented.md")
+        body = NL.join(["# note", "",
+                        "    " + BT * 3,
+                        "", "The doctor covers 19 of these %d entries." % (n - 4)]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("2026-01-01-indented.md" in f["where"]
+                            for f in findings_of(out, "COUNT")),
+                        "an indented backtick line must not open a fence")
+
+    def test_51_tilde_fenced_capture_is_exempt(self):
+        """Tilde fences are valid Markdown and carry captured output too."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-tilde.md")
+        body = NL.join(["# note", "", "~~~",
+                        "implemented 19/%d" % (n - 4),
+                        "~~~"]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-tilde.md" in f["where"]]
+        self.assertEqual(counts, [], "a tilde-fenced capture must be exempt")
+
+    def test_52_escaped_backticks_do_not_make_a_code_span(self):
+        """Escaped backticks render literally. Counting them would let prose
+        masquerade as captured output."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-escaped.md")
+        esc = chr(92) + BT
+        body = NL.join(["# note", "",
+                        "Prose with " + esc + "implemented 19/%d" % (n - 4) + esc + " inline."]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("2026-01-01-escaped.md" in f["where"]
+                            for f in findings_of(out, "COUNT")),
+                        "escaped backticks must not open a code span")
 
 class ClaimLedgerMutations(unittest.TestCase):
     """The claim-propagation checks, including the requirement that made the

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -434,6 +434,34 @@ class RegistryMutations(unittest.TestCase):
         self.assertEqual(counts, [], "an inner shorter fence must not close "
                                      "the outer block: %s" % counts)
 
+
+    def test_55_invalid_backtick_info_string_does_not_open_a_fence(self):
+        """A backtick fence info string may not contain a backtick. Opening on
+        one would exempt every live claim after it, which is a leak."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-infostring.md")
+        write(p, NL.join(["# note", "",
+                          BT*3 + "python" + BT + "example",
+                          "", "The doctor covers 19 of these %d entries." % (n - 4)]) + NL)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("2026-01-01-infostring.md" in f["where"]
+                            for f in findings_of(out, "COUNT")),
+                        "an invalid backtick info string must not open a fence")
+
+    def test_56_closing_fence_must_be_bare(self):
+        """Non-whitespace after the delimiter means content, not a close."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-bareclose.md")
+        write(p, NL.join(["# note", "", "~~~",
+                          "~~~ still running",
+                          "implemented 19/%d" % (n - 4),
+                          "~~~"]) + NL)
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-bareclose.md" in f["where"]]
+        self.assertEqual(counts, [], "a non-bare delimiter line is content: %s" % counts)
+
 class ClaimLedgerMutations(unittest.TestCase):
     """The claim-propagation checks, including the requirement that made the
     whole thing enforceable."""

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -26,6 +26,8 @@ import sys
 import tempfile
 import unittest
 
+NL = chr(10)
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 INTEGRITY = os.path.dirname(HERE)
 REPO = os.path.dirname(INTEGRITY)
@@ -281,6 +283,73 @@ class RegistryMutations(unittest.TestCase):
         self.assertEqual(rc, 1)
         fb = findings_of(out, "FOUND-BY")
         self.assertTrue(any("33-moe" in f["where"] for f in fb), fb)
+
+
+    # --- captured-output exemption under mining/ ---------------------------
+    #
+    # A mining note records a run. When it pastes the coverage line a tool
+    # printed, that number must keep saying what it printed. The exemption is
+    # narrow on purpose and these four fixtures pin it: the capture passes,
+    # and prose in the same file, a README count and a code span outside
+    # mining/ all still fail.
+
+    def test_46_captured_output_in_a_mining_note_is_exempt(self):
+        """POSITIVE: a stale count inside a code span under mining/ passes,
+        because it is a capture of what a tool printed on a date."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-captured-run.md")
+        body = NL.join([
+            "# A dated run", "",
+            "The doctor printed:", "",
+            "| Arm | Coverage line |", "|---|---|",
+            "| one | `implemented 19/%d | not implemented 84` |" % (n - 4),
+        ]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-captured-run.md" in f["where"]]
+        self.assertEqual(counts, [], "a captured coverage line under mining/ "
+                                     "must not be read as a live claim: %s" % counts)
+
+    def test_47_prose_in_a_mining_note_is_NOT_exempt(self):
+        """NEGATIVE: the same stale number as ordinary prose in the same
+        directory is a current assertion and must still fail."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-prose-claim.md")
+        body = NL.join(["# A summary", "",
+                        "The doctor covers 19 of these %d entries." % (n - 4)]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-prose-claim.md" in f["where"]]
+        self.assertTrue(counts, "prose in a mining note is a live claim and "
+                               "must still be enforced")
+
+    def test_48_readme_count_is_never_exempt(self):
+        """NEGATIVE: the exemption is scoped to mining/ and must not leak."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "README.md")
+        text = read(p)
+        after = text.replace("All %d entries" % n, "All %d entries" % (n - 4), 1)
+        self.assertNotEqual(text, after, "fixture drift: README All N entries")
+        write(p, after)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("README.md" in f["where"]
+                            for f in findings_of(out, "COUNT")))
+
+    def test_49_code_span_outside_mining_is_never_exempt(self):
+        """NEGATIVE: backticks are not on their own a licence. The same
+        capture-shaped line outside mining/ is still enforced."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "doctor", "SCRATCH_NOTE.md")
+        body = NL.join(["# scratch", "", "`implemented 19/%d`" % (n - 4)]) + NL
+        write(p, body)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("SCRATCH_NOTE.md" in f["where"]
+                            for f in findings_of(out, "COUNT")))
 
 
 class ClaimLedgerMutations(unittest.TestCase):
@@ -630,6 +699,7 @@ class DoNotCiteMutations(unittest.TestCase):
         self.assertEqual(rc, 1, out)
         self.assertTrue(any(h["path"] == "NEW_WRITEUP.md" for h in out["hits"]),
                         out)
+
 
 
 if __name__ == "__main__":

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -403,6 +403,37 @@ class RegistryMutations(unittest.TestCase):
                             for f in findings_of(out, "COUNT")),
                         "escaped backticks must not open a code span")
 
+
+    def test_53_multi_backtick_code_span_is_exempt(self):
+        """A code span is delimited by EQUAL-LENGTH backtick runs. Captured
+        output often needs the double form because it contains a backtick."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-multitick.md")
+        inner = BT + "field" + BT
+        line = BT*2 + "implemented 19/%d with %s " % (n - 4, inner) + BT*2
+        write(p, NL.join(["# note", "", line]) + NL)
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-multitick.md" in f["where"]]
+        self.assertEqual(counts, [], "a multi-backtick capture must be exempt")
+
+    def test_54_longer_fence_is_not_closed_by_a_shorter_inner_one(self):
+        """A closing fence must be at least as long as the opener, so a three
+        backtick line inside a four backtick block is content, not a close."""
+        n = entry_count(self.root)
+        p = os.path.join(self.root, "mining", "2026-01-01-nested.md")
+        write(p, NL.join(["# note", "",
+                          BT*4,
+                          BT*3 + "text",
+                          "implemented 19/%d" % (n - 4),
+                          BT*3,
+                          BT*4]) + NL)
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "2026-01-01-nested.md" in f["where"]]
+        self.assertEqual(counts, [], "an inner shorter fence must not close "
+                                     "the outer block: %s" % counts)
+
 class ClaimLedgerMutations(unittest.TestCase):
     """The claim-propagation checks, including the requirement that made the
     whole thing enforceable."""


### PR DESCRIPTION
*Drafted with AI assistance (Claude); reviewed and submitted by @Blackwellboy.*

Maintainer-only. **No contributor content is included.**

## The defect

The COUNT checker reads a captured tool output as a live claim about the current tree.

Concretely: a dated `mining/` note pastes the coverage line a doctor actually printed, `implemented 19/103 | ... | not implemented 84`. That was true when it ran. The registry has since grown to 107, so the checker fails the note, and the only way to satisfy it would be to **rewrite what the tool printed**. That falsifies evidence, which is a failure this registry catalogues rather than commits.

`CHANGELOG.md` is already exempt for exactly this reason, in the checker's own words:

> an append-only record of what was true on a date ... must keep saying 42 after the tree grows, or the log stops being a log

A dated mining note is the same class. This extends that rule, narrowly.

## The rule, and why it is not "ignore numbers under mining/"

The exemption applies **only** where the number sits inside a code span or a fenced block, which is how captured output is written and how a live assertion is not:

| Surface | Example | Exempt |
|---|---|---|
| `mining/note.md` | `` `implemented 19/103 | ...` `` | **yes**, it is a capture |
| `mining/note.md` | `19 of these 103 entries` | **no**, that is prose making a claim |
| `README.md` | anything | **no**, ever |
| `traps/**` | anything | **no**, ever |
| `doctor/note.md` | `` `implemented 19/103` `` | **no**, backticks alone are not a licence |

Prose in a mining summary is a current claim and stays enforced. The directory scope and the code-span requirement are two independent conditions and both must hold.

## Fixtures, one positive and three negative

- `test_46` captured coverage line under `mining/` in a code span **passes**
- `test_47` the same stale number as prose in a mining note **still fails**
- `test_48` a stale count in `README.md` **still fails**
- `test_49` a capture-shaped code span **outside** `mining/` **still fails**

## Mutation-proven in both directions

Not asserted, run:

```
exemption forced OFF  (return False)  ->  test_46 FAILS   (the rule is load-bearing)
exemption forced ON   (return True)   ->  test_47 FAILS
                                          test_48 FAILS
                                          test_49 FAILS   (the narrowing is load-bearing)
restored                              ->  97 tests OK
```

A rule that only widens what passes is untestable in the direction that matters. Both directions are pinned.

## Checks

```
registry integrity  CLEAN: 863 checks over 107 entries    claim propagation  PASS
reference integrity PASS       do-not-cite  PASS          doctor/tests       PASS
upstream tier       PASS       sanitizer    PASS          checks/tests       PASS
integrity/tests     97 tests OK  (93 before, +4 fixtures)
public surfaces     CLEAN with peers supplied
git diff --check    clean
private sanitizer   CLEAN     supplementary whole-tree scan  CLEAN
```

Two files changed: `integrity/registry_integrity.py` and `integrity/tests/test_mutations.py`.

## Context, not included here

This surfaced while simulating the merge of contributor PR [#8](https://github.com/Blackwellboy/model-serving-minefield/pull/8), whose mining note carries the captured line above. **That PR's content is deliberately not in this branch** so it stays the contributor's work, and he has been told explicitly not to "fix" the 103 and 84 in his note, because they are what his run printed.
