### PR TITLE
queue: the doctor-coverage sentence was stale, and no pattern could see it

### DIFF
--- a/integrity/registry_integrity.py
+++ b/integrity/registry_integrity.py
@@ -269,6 +269,12 @@ TOTAL_PATTERNS = [
     (re.compile(r"implemented\s+(\d+)\s*/\s*(\d+)"), 2, 1),
     # the same line built in a test f-string: implemented {len(md.TRAP_PATHS)}/42
     (re.compile(r"implemented\s+\{[^}]*\}\s*/\s*(\d+)"), 1, None),
+    # "**19 of 97** entries", where the bold spans BOTH numbers and there is
+    # no "these"/"this registry's" between them. This exact shape sat in
+    # mining/OPEN_QUESTIONS.md and drifted to 19 of 97 while the tree grew to
+    # 107, because every pattern above requires a qualifier word the sentence
+    # does not have. A coverage total is a total however the bold is placed.
+    (re.compile(r"\*\*(\d+)\s+of\s+(\d+)\*\*\s+entries"), 2, 1),
     # "all 42 entries", "All 42 entries". Two of these sat in README.md
     # unguarded while the neighbouring "N of these 42 entries" lines were
     # checked, so the same number was enforced in one sentence and typed by
@@ -287,6 +293,10 @@ TOTAL_PATTERNS = [
 # cannot go stale again.
 ORPHAN_PATTERNS = [
     re.compile(r"not\s+implemented\s+\*{0,2}(\d+)\*{0,2}\b"),
+    # "the 78 uncovered entries". Same fossilising shape as "not implemented
+    # N": it states the DIFFERENCE, so no total-pattern sees it, and it
+    # survived a registry expansion in mining/OPEN_QUESTIONS.md.
+    re.compile(r"\b(\d+)\s+uncovered\s+entries\b"),
     re.compile(r"remaining\s+\*{0,2}(\d+)\*{0,2}\s+numbered\s+traps"),
 ]
 

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -462,6 +462,87 @@ class RegistryMutations(unittest.TestCase):
                   if "2026-01-01-bareclose.md" in f["where"]]
         self.assertEqual(counts, [], "a non-bare delimiter line is content: %s" % counts)
 
+
+    # --- doctor-coverage prose in mining/OPEN_QUESTIONS.md ---------------
+    #
+    # This sentence drifted to "19 of 97 / 78 uncovered" while the tree grew
+    # to 107, because its bold spans BOTH numbers and no pattern required
+    # that shape, and because "uncovered" states the DIFFERENCE rather than a
+    # total. Two patterns now cover it. These fixtures pin both, and pin that
+    # each fails for its own assertion rather than for the other one.
+
+    def _oq(self):
+        return os.path.join(self.root, "mining", "OPEN_QUESTIONS.md")
+
+    def test_57_correct_coverage_prose_passes(self):
+        """POSITIVE: the corrected sentence produces no COUNT finding."""
+        rc, out = run_registry(self.root)
+        counts = [f for f in findings_of(out, "COUNT")
+                  if "OPEN_QUESTIONS.md" in f["where"]]
+        self.assertEqual(counts, [], "clean tree must not flag the prose: %s" % counts)
+
+    def test_58_stale_registry_total_fails(self):
+        """NEGATIVE: 107 -> 97 fails, and names the TOTAL assertion."""
+        n = entry_count(self.root)
+        t = read(self._oq())
+        after = t.replace("**19 of %d** entries" % n, "**19 of %d** entries" % (n - 10), 1)
+        self.assertNotEqual(t, after, "fixture drift: coverage sentence")
+        write(self._oq(), after)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        hits = [f for f in findings_of(out, "COUNT")
+                if "OPEN_QUESTIONS.md" in f["where"] and "registry total" in f["message"]]
+        self.assertTrue(hits, "must fail on the registry total specifically")
+
+    def test_59_stale_uncovered_count_fails(self):
+        """NEGATIVE: 88 -> 78 fails, and names the not-implemented assertion,
+        with the registry total left correct so the two cannot be confused."""
+        n = entry_count(self.root)
+        t = read(self._oq())
+        after = t.replace("  %d uncovered entries" % (n - 19),
+                          "  %d uncovered entries" % (n - 29), 1)
+        self.assertNotEqual(t, after, "fixture drift: uncovered sentence")
+        write(self._oq(), after)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        hits = [f for f in findings_of(out, "COUNT")
+                if "OPEN_QUESTIONS.md" in f["where"] and "not-implemented" in f["message"]]
+        self.assertTrue(hits, "must fail on the uncovered count specifically")
+        totals = [f for f in findings_of(out, "COUNT")
+                  if "OPEN_QUESTIONS.md" in f["where"] and "registry total" in f["message"]]
+        self.assertEqual(totals, [], "must NOT also fire the total assertion")
+
+    def test_60_stale_doctor_coverage_fails(self):
+        """NEGATIVE: 19 -> 18 fails on the doctor-coverage half."""
+        n = entry_count(self.root)
+        t = read(self._oq())
+        after = t.replace("**19 of %d** entries" % n, "**18 of %d** entries" % n, 1)
+        self.assertNotEqual(t, after, "fixture drift")
+        write(self._oq(), after)
+        rc, out = run_registry(self.root)
+        self.assertEqual(rc, 1)
+        hits = [f for f in findings_of(out, "COUNT")
+                if "OPEN_QUESTIONS.md" in f["where"] and "doctor coverage" in f["message"]]
+        self.assertTrue(hits, "must fail on doctor coverage specifically")
+
+    def test_61_patterns_actually_match_a_known_string(self):
+        """A guard whose regex silently matches nothing passes every tree.
+
+        The first version of the uncovered-count pattern was written with a
+        literal backspace byte instead of a word boundary, so it compiled,
+        loaded and matched NOTHING. Zero inspected matches must not be able to
+        look like a pass, so assert the patterns fire on a known string.
+        """
+        import registry_integrity as ri
+        total_line = "checks for **19 of 107** entries and"
+        orphan_line = "  88 uncovered entries are reachable"
+        self.assertTrue(
+            any(rx.search(total_line) for rx, _t, _i in ri.TOTAL_PATTERNS),
+            "no TOTAL pattern matches the bold-spanning coverage sentence")
+        self.assertTrue(
+            any(rx.search(orphan_line) for rx in ri.ORPHAN_PATTERNS),
+            "no ORPHAN pattern matches the uncovered-entries sentence")
+
 class ClaimLedgerMutations(unittest.TestCase):
     """The claim-propagation checks, including the requirement that made the
     whole thing enforceable."""

--- a/integrity/tests/test_mutations.py
+++ b/integrity/tests/test_mutations.py
@@ -533,7 +533,17 @@ class RegistryMutations(unittest.TestCase):
         loaded and matched NOTHING. Zero inspected matches must not be able to
         look like a pass, so assert the patterns fire on a known string.
         """
-        import registry_integrity as ri
+        # Loaded from an absolute path derived from INTEGRITY, not from
+        # sys.path. Running this file as `python3 -m unittest
+        # integrity.tests.test_mutations` does not put integrity/ on the path,
+        # and a bare import would raise ModuleNotFoundError, which is an ERROR
+        # rather than this assertion failing. A guard test that cannot run is
+        # the same defect class it exists to catch.
+        import importlib.util
+        _spec = importlib.util.spec_from_file_location(
+            "_ri_for_test", os.path.join(INTEGRITY, "registry_integrity.py"))
+        ri = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(ri)
         total_line = "checks for **19 of 107** entries and"
         orphan_line = "  88 uncovered entries are reachable"
         self.assertTrue(

--- a/mining/OPEN_QUESTIONS.md
+++ b/mining/OPEN_QUESTIONS.md
@@ -153,9 +153,9 @@ hour, `M` a few hours, `L` a day or more, `XL` needs hardware nobody here has.
 
 ### Q9. Which uncovered entries deserve a doctor check?
 
-- **Claim under test.** The doctor implements checks for **19 of 97** entries and
+- **Claim under test.** The doctor implements checks for **19 of 107** entries and
   says so on every run. That is a coverage statement, not a plan. Which of the
-  78 uncovered entries are reachable by a request-shaped probe is unanswered.
+  88 uncovered entries are reachable by a request-shaped probe is unanswered.
 - **Source.** PRIMARY, ours.
 - **Needs.** No hardware. Reading, plus a lane to validate any check written.
 - **CONFIRM.** A candidate is reachable if a probe can distinguish the trap from


### PR DESCRIPTION
*Drafted with AI assistance (Claude); reviewed and submitted by @Blackwellboy.*

## The stale sentence

`mining/OPEN_QUESTIONS.md`, Q9, said the doctor covers **19 of 97** entries with **78 uncovered**. The tree holds **107** entries with **19** doctor-covered, so the uncovered count is **88**. Verified from source: `registry_integrity.py` enumerates 107, and `doctor/minefield_doctor.py` `TRAP_PATHS` holds 19.

Corrected to **19 of 107** and **88 uncovered**.

## Why it went stale, and why patching the sentence was not enough

Neither number was covered by any pattern:

- **`**19 of 97** entries`** puts the bold around *both* numbers with no `these` / `this registry's` between them. Every existing total-pattern requires that qualifier word, so none matched.
- **`78 uncovered entries`** states the **difference**, which is the fossilising shape the orphan patterns exist for, but they only knew `not implemented N` and `remaining N numbered traps`.

Two patterns added, so this sentence is now derived rather than hand-typed.

## A guard that could not fail, caught by its own fixture

The first version of the uncovered-count pattern was written with a **literal backspace byte (`\x08`) where a word boundary was intended**. It compiled, imported and matched **nothing**, so the mutation test passed for the wrong reason: the tree looked clean because the guard was inert, not because the count was right.

It is invisible in normal output. Only `repr()` shows it:

```
'\x08(\d+)\s+uncovered\s+entries\x08'
```

`test_61` exists because of that: it asserts both pattern families actually fire on a known string, so **zero inspected matches can never look like a pass**.

## Fixtures

| Test | Asserts |
|---|---|
| 57 | correct values produce no finding |
| 58 | 107 to 97 fails, **on the registry-total assertion** |
| 59 | 88 to 78 fails, **on the not-implemented assertion**, and asserts the total assertion does **not** also fire |
| 60 | 19 to 18 fails, **on the doctor-coverage assertion** |
| 61 | both pattern families match a known string; an inert regex cannot pass |

58, 59 and 60 each check the finding **message**, so a test cannot be satisfied by an unrelated guard firing. Mutation-verified independently: each stale value fails alone, and both stale together produce exactly two findings.

Tests 104 to **109**.

## Checks

```
registry integrity  PASS   claim propagation PASS   integrity/tests 109 OK
reference integrity PASS   do-not-cite       PASS   doctor/tests    PASS
upstream tier       PASS   sanitizer         PASS   checks/tests    PASS
check contract      ALL PASS (9 conform, 1 non-Python)
public surfaces     CLEAN with peers supplied
git diff --check    clean
private sanitizer   CLEAN     supplementary whole-tree scan  CLEAN
```
