### PR TITLE
Muse: offlabel cross-check + RTX 5090 closing repro

### DIFF
--- a/mining/2026-08-11-muse-glimmer-30b-reasoning-control-and-stack.md
+++ b/mining/2026-08-11-muse-glimmer-30b-reasoning-control-and-stack.md
@@ -83,6 +83,58 @@ Same host class, HumanEval+ only, greedy: Qwen3.6-27B Q4_K_M with MTP reasoning-
 - Do not treat aggregate concurrency throughput alone as "faster for agents" without per-request latency.
 - Multimodal capability was **not** tested (no vision projector in the pin).
 
+## Update 2026-08-12: offlabel cross-check + bounded RTX 5090 follow-up
+
+Tom Turney's public [offlabel Muse Glimmer 30B guide](https://github.com/TheTom/offlabel/blob/main/models/muse-glimmer-30b.md) landed on 2026-08-11 after a separate release-day behavioral/serving battery. Treat it as **external evidence with its own scope** (GB10 for most serving work, different quant, single tester), not as a replacement for the measurements above.
+
+### What independently lined up
+
+- The shipped template/control story matched: absent `reasoning_strength` resolves high; card-style system LOW leaves a contradictory LOW+HIGH render; `chat_template_kwargs.reasoning_strength` is the effective lever. offlabel also reports `enable_thinking` and top-level `reasoning_effort` inert on its path. For the dead-knob observation, offlabel explicitly credits Blackwellboy's same-day report, so this is **independent execution, not clean independent discovery**.
+- offlabel's DFlash story is workload-sensitive in the same direction as our 48-prompt acceptance matrix. Our matrix is the quantitative owner here; the external result is corroboration, not a new speed constant.
+- offlabel also found greedy DFlash output non-identity. Different hardware/quant means the exact rates are not directly comparable.
+
+### Bounded RTX 5090 reproduction of the new operator gotchas
+
+A follow-up on our pinned RTX 5090 lane tested four short sequential serve arms on 8 representative prompts:
+
+| Arm | Configuration | Mean wall | Draft counters | Exact vs target-only arm |
+|---|---|---:|---|---:|
+| A | target only | 1.065 s | none | - |
+| B | `--model-draft` only | 1.039 s | none | 6/8 |
+| C | `draft-dflash`, n_max=3 | 0.748 s | present | 6/8 |
+| D | `draft-dflash`, n_max=15 | 0.640 s | present | 5/8 |
+
+**Measured operator lesson:** a drafter can log as loaded without speculative decoding being active. On this build, the `--model-draft`-only arm had no draft/acceptance counters and behaved like target-only, while explicit `--spec-type draft-dflash` produced counters and the expected latency reduction. Do not use "draft model loaded" as the proof of activation; verify the speculative implementation and live counters.
+
+This does **not** invalidate the earlier Muse DFlash measurements: those stored runs used `draft-dflash`, n_max=15, and preserved draft/acceptance counters.
+
+### Greedy identity: stronger boundary, still not a correctness claim
+
+Before comparing DFlash, the target-only path was repeated three times on 12 prompts; **10/12** were byte-identical across all three repetitions. In the bounded A-vs-D comparison, only **5/8** outputs were exact matches.
+
+That supports the existing [trap 111](../traps/evaluation/111-greedy-spec-decode-medians-are-a-content-lottery.md) boundary that task/quality parity is not text identity. It does **not** establish a DFlash correctness defect: the target-only path itself was not perfectly reproducible, and the 8-prompt follow-up was not a graded semantic suite.
+
+### Agent harness: correct tool call can still end in a wrong final
+
+A 20-task deterministic tool-result fidelity battery produced **20/20 correct tool calls** but **2/20 final summaries that did not match the tool result**. There were **0** cases where the final simply substituted the value the user originally expected; the two misses were final-answer fidelity failures, not tool-selection failures.
+
+Practical harness rule: score the user-facing final answer against the actual tool result. `tool_call_correct=true` is not enough to prove the task completed correctly.
+
+### Behavioral cross-checks that should stay model notes, not serving traps
+
+- **Clean-code calibration corroborated:** Muse invented a defect in **0/12** clean snippets and accepted all 12 as correct. On a matched 12-bug set it found **8/12**. The positive result is specifically low false-defect rate; do not rewrite it as perfect bug detection.
+- **Turn-2 refusal collapse did not cleanly reproduce here:** in a 12-scenario bounded reframe battery there were **0** strict `TURN1_HELD -> TURN2_FOLDED` transitions under the campaign scorer. Some cases moved to partial. offlabel's held-then-fold example remains valid for its battery; our result says not to generalize it as a guaranteed Muse behavior across prompts/stacks.
+
+### Routing after the cross-check
+
+- **No new public trap number.**
+- `--model-draft` loaded != speculative decoding active: verified operator/llama.cpp stack candidate; keep as mining/stack guidance unless a distinct general mechanism clears the normal promotion bar.
+- DFlash exact-text non-identity: existing trap 111 corroboration/claim boundary.
+- Correct tool call != correct final summary: research-harness/playbook extension candidate, not evidence that native tool calling is broken.
+- Clean-code false-defect result and refusal/reframe behavior: model characterization only.
+
+*Status of 2026-08-12 update: measured here, raw not published. External offlabel claims remain attributed to their source and are not relabelled as Blackwellboy measurements.*
+
 ## Related entries updated in the same PR
 
 Addenda on traps **07, 12, 21, 42, 77, 78, 111**; model index row; llama.cpp stack pointer; playbook note on content-only extract + render provenance.


### PR DESCRIPTION
## Summary

Adds a dated 2026-08-12 follow-up to the existing Muse Glimmer 30B mining note after Tom/offlabel PR #23 landed publicly and after a bounded Blackwellboy RTX 5090 reproduction pass.

### New public-safe evidence

- External offlabel cross-check: reasoning-control/template behavior and workload-sensitive DFlash story line up with our prior campaign, with attribution kept explicit.
- RTX 5090: `--model-draft` alone can log/load a drafter while speculative decoding remains inactive (no draft counters; target-like timing). Proper `--spec-type draft-dflash` activates counters and reduces latency.
- RTX 5090 greedy boundary: target-only triple exact 10/12; DFlash n_max=15 exact vs target 5/8. Recorded as non-identity / Trap 111 claim boundary, **not** a correctness defect.
- Agent harness: 20/20 correct tool calls, but 2/20 final summaries failed to match the tool result. Records the harness rule that final user-facing output must be checked against tool evidence.
- Clean-code calibration: 0/12 false defects, 8/12 matched real bugs found.
- Tom's strict turn-1-held → turn-2-fold pattern did not reproduce cleanly in our 12-case scorer (0/12 strict transitions), so it remains externally scoped rather than generalized.

## Governance

- New trap IDs: **0**
- Existing trap files changed: **0**
- Generated registry/bundle surfaces changed: **0**
- Raw private evidence: not published
- External claims remain attributed to TheTom/offlabel

This is intentionally a mining-note update only: verified new evidence is public, while stack/playbook promotion can follow separately if/when we want to regenerate the derived agent surfaces.