### PR TITLE
Add OBLIT packing and runtime-ablation evidence

### DIFF
--- a/mining/2026-08-25-oblit-packing-and-runtime-ablation.md
+++ b/mining/2026-08-25-oblit-packing-and-runtime-ablation.md
@@ -1,0 +1,118 @@
+# 2026-08-25: matched OBLIT packing and runtime refusal-direction ablation
+
+Status: **first-party evidence note; raw packets remain private**.
+
+This note records two same-day experiments that materially sharpen existing
+Minefield entries without creating new trap numbers.
+
+## 1. Qwen3.8-27B OBLITERATED: packing, not abliteration, dominated the earlier speed gap
+
+Private owning evidence:
+
+- repo: `Blackwellboy/blackwellbench-lab`
+- branch: `research/qwen38-abliterated-autoround-investigation-20260824`
+- evidence commit: `1e43f3273daca8ebf7292bd161b64fbdeb0124f3`
+- path: `research/qwen38-abliterated-autoround-investigation-20260824/optimization/`
+
+The first OBLIT AutoRound candidate exported through `--format auto_gptq` and
+identified as `quant_method=gptq` with `g_idx`. It ran through the GPTQ/Marlin
+path and measured about 191.9 tok/s on the matched code cell.
+
+Candidate D rebuilt the exact same OBLIT BF16 source into the packing identity
+used by the fast Frozenlock reference: `auto_round:auto_gptq`, `g_idx=0`,
+matched qweight inventory, matched MTP treatment and matched auxiliary-tensor
+size.
+
+Matched vLLM + DFlash2 K7 results:
+
+| metric | Frozenlock normal | OBLIT Candidate D |
+|---|---:|---:|
+| code tok/s | 233.83 | 233.10 |
+| code acceptance | 80.3% | 79.9% |
+| prose tok/s K7 | 107.15 | 101.18 |
+| prose acceptance K7 | 21.6% | 20.0% |
+| finished-work sum mean wall | 2.49 s | 2.23 s |
+| tiny intelligence smoke | 8/8 | 7/8 |
+
+The OBLIT target reached 109.43 prose tok/s at K6. K7 remained the clear code
+winner. The one intelligence-smoke miss was a strict tool-call format near-miss;
+the experiment does not support a universal intelligence-equivalence claim.
+
+**Disposition:** strong new first-party instance for
+[`Trap 10`](../traps/quantization/10-quant-label-is-not-the-kernel-path.md).
+The key failure mode is export/packing identity: two artifacts that can both be
+described loosely as W4A16/group-128 AutoRound did not land on the same runtime
+representation or speed class.
+
+**Claim boundary:** this does not establish that abliteration has zero cost in
+general. It establishes that the earlier ~18% route-level code gap in this
+campaign was dominated by the unmatched export/packing path; after packing was
+matched, code speed and speculative acceptance were effectively at the
+reference level in this session.
+
+## 2. DeepSeek-v4-Flash one-DGX-Spark: same weights and same image digest, runtime overlay changes refusal behavior
+
+Private owning evidence:
+
+- repo: `Blackwellboy/openclaw-workspace`
+- evidence commit: `022d4dce39fe8fbbd37c587c7349a17683311283`
+- path: `chatgpt-returns/mia-dsv4-runtime-ablate-20260824`
+- upstream Mia pin: `bf162cce0ed8c0dfcba645f7addf60b07823550f`
+
+Dexter2 kept the same EXL3 checkpoint bytes and the same pinned runtime image.
+Mia's opt-in `ABLATE=1` path bind-mounted a model-code overlay and projected the
+published refusal direction at runtime with:
+
+- lambda: 3.5
+- layers: 10-42
+- direction SHA256:
+  `6e4d8a8f3aa9e21795faab2c5b14d29b019acdf2ddbfbd8238430458a5837fe0`
+- weights changed: no
+- weights re-downloaded: no
+- DSpark K: 5
+- context: 384000 before and after
+
+Matched behavior/performance:
+
+| metric | stock | runtime ABLATE |
+|---|---:|---:|
+| refusals, thinking off | 8/8 | 0/8 |
+| refusals, thinking on | 7/8 | 0/8 |
+| capability smoke, thinking off | 6/6 | 6/6 |
+| capability smoke, thinking on | 2/6 | 2/6 |
+| code tok/s | 36.621 | 36.985 |
+| prose tok/s | 21.841 | 22.812 |
+| DSpark code acceptance | 0.5463 | 0.5477 |
+| DSpark prose acceptance | 0.2568 | 0.2710 |
+
+The thinking-on 2/6 result was the same empty-content-at-length/reasoning-budget
+artifact on both arms, so the bounded smoke found no obvious capability
+regression from the runtime projection. A 13,558-token retrieval sanity check
+passed, and Hermes continued to reach the lane.
+
+**Disposition:** supporting instance for
+[`Trap 09`](../traps/runtime/09-image-choice-changes-outcome.md), specifically a
+sharpening of its unit-under-test rule. An image digest by itself does not fully
+identify a runtime when model code is replaced by a bind mount or overlay.
+Record mounted code, injected files/config and compile/AOT cache identity as
+part of the serving artifact.
+
+This is **not** another instance of
+[`Trap 14`](../traps/versioning/14-finetune-reupload-not-drop-in.md): there was
+no finetuned/abliterated weight re-upload in this experiment. The weights stayed
+unchanged; the behavioral intervention lived in the runtime path.
+
+## Combined lesson
+
+Both experiments are the same higher-level discipline from opposite sides:
+**artifact identity must describe the code path that actually executes, not the
+label humans use for it.**
+
+- Quantization recipe labels can hide a different packed representation and
+  loader/kernel path.
+- Image digests can hide runtime-mounted model code that changes behavior with
+  identical weights.
+
+For publishable comparisons, record the full execution identity: checkpoint
+revision and hashes, packing/export metadata, auxiliary-head treatment, image
+digest, mounted overlays, runtime config and the backend actually selected.

--- a/traps/quantization/10-quant-label-is-not-the-kernel-path.md
+++ b/traps/quantization/10-quant-label-is-not-the-kernel-path.md
@@ -51,8 +51,7 @@ Then answer: which kernel family does this `quant_method` route to in YOUR
 build on YOUR arch, and is that the fast path or a weight-only fallback? If
 you cannot answer from the config plus your build, expect the fallback.
 
-**The fix.** Choose checkpoints whose format matches a kernel path your
-hardware actually has. State the kernel path next to every published speed
+**The fix.** Choose checkpoints whose format matches a kernel path your hardware actually has. State the kernel path next to every published speed
 number, because the label alone under-determines it.
 
 **Found.** 2026-07-09; hardware claim verified locally 2026-07-10.
@@ -102,3 +101,39 @@ disagreement is silent.
 *Status of this addendum: reproduced here. The `quantization_config` block and
 the HF `8-bit` tag are public and checkable without us; the backend binding is
 in the engine's own startup log on any lane serving the checkpoint.*
+
+## Added 2026-08-25: AutoRound export packing changed the speed class
+
+**Status of this addendum: measured here, raw not published.** The full build
+and benchmark packet is retained privately; the numbers below are the
+claim-scoped summary from one RTX 5090 campaign.
+
+A Qwen3.8-27B OBLITERATED W4A16/group-128 rebuild produced two artifacts that
+could both casually be described as "AutoRound INT4", but they did not encode
+the same runtime representation. The first export, made through
+`--format auto_gptq`, identified as `quant_method=gptq`, carried `g_idx`, and
+served through the GPTQ/Marlin path. A second rebuild reconstructed the known
+fast reference packing as `auto_round:auto_gptq`, with `g_idx=0`, matched
+qweight inventory, matched MTP treatment, and the same auxiliary-tensor size as
+the reference artifact.
+
+On the same RTX 5090, the same vLLM+DFlash2 stack and K7 speculative depth, the
+packing change moved code decode from about **191.9 tok/s** to **233.1 tok/s**.
+The matched non-abliterated Frozenlock reference measured **233.83 tok/s** in
+the same session. Code speculative acceptance was likewise essentially matched
+(**79.9%** OBLIT versus **80.3%** reference). Prose remained workload-sensitive:
+OBLIT K7 measured **101.18 tok/s** versus **107.15 tok/s** reference, while the
+same OBLIT target reached **109.43 tok/s** at K6.
+
+The useful conclusion is narrower than "abliteration is free": **the earlier
+~18% route-level gap was dominated by export/packing identity, not by the target
+weight intervention.** Only after the packing and MTP treatment matched did the
+code path return to reference-class speed. Behavior/correctness checks remained
+green on the matched OBLIT target.
+
+**The extra check this instance adds:** for AutoRound/GPTQ-family artifacts,
+do not stop at bits, group size and a marketing label. Record and compare
+`quant_method`, export format, `g_idx` presence, packed tensor inventory,
+auxiliary/MTP treatment, and the loader/kernel actually selected at runtime.
+Two "W4A16 group-128 AutoRound" checkpoints can otherwise land in different
+speed classes without an obvious launch error.

--- a/traps/runtime/09-image-choice-changes-outcome.md
+++ b/traps/runtime/09-image-choice-changes-outcome.md
@@ -42,3 +42,42 @@ number. When a result surprises you, the image is a first-class suspect.
 **Found.** 2026-07-09, public writeup in the Hy3 repo.
 
 **Attribution.** Blackwellboy; eugr's image is credited as the working path.
+
+## Added 2026-08-25: a bind-mounted runtime overlay changed behavior with the image digest and weights unchanged
+
+**Status of this addendum: measured here, raw not published.** This is a
+supporting instance that sharpens the unit-under-test rule; it is not a new
+public trap number.
+
+On a single DGX Spark serving DeepSeek-v4-Flash 0731 EXL3 with DSpark K5, the
+checkpoint bytes and container image digest were held fixed while an opt-in,
+read-only `model.py` overlay projected a published refusal direction out of the
+attention output stream at runtime. The overlay was enabled with `ABLATE=1`,
+`lambda=3.5`, layers 10-42. No model weights were edited or re-downloaded.
+
+The behavioral result changed dramatically despite identical weight identity
+and unchanged image digest:
+
+- thinking off: **8/8 refusals -> 0/8**;
+- thinking on: **7/8 refusals -> 0/8**.
+
+A small matched capability smoke showed no obvious regression: stock and
+runtime-ablated arms both scored 6/6 with thinking off and 2/6 with thinking on;
+the thinking-on misses were the same empty-content-at-length/reasoning-budget
+artifact in both arms. Performance did not regress in the matched cells: code
+was **36.621 -> 36.985 tok/s** and prose **21.841 -> 22.812 tok/s**. DSpark
+acceptance also stayed effectively flat/slightly higher (code **0.5463 ->
+0.5477**, prose **0.2568 -> 0.2710**). A 13,558-token retrieval sanity check
+passed with no NaNs.
+
+This instance exposes a boundary in the original wording: **pinning the image
+digest is necessary but not sufficient when runtime code can be bind-mounted or
+otherwise overlaid.** The practical unit under test is at least:
+
+`image digest + weights + mounted/overlaid code + runtime config + hardware`.
+
+**The extra check this instance adds:** record read-only bind mounts, injected
+model-code overlays, and compile/AOT cache identity next to the image digest.
+When toggling an overlay, prove from the live process/logs that the intended code
+is actually mounted and active; otherwise a supposedly matched A/B can compare
+stale compiled code to the new configuration.


### PR DESCRIPTION
Adds two first-party evidence updates without creating new trap numbers:

- Trap 10: Qwen3.8 OBLITERATED AutoRound Candidate D shows the earlier ~18% code gap was dominated by export/packing identity (`gptq+g_idx` vs matched `auto_round:auto_gptq`), with matched code speed ~233.1 vs 233.83 tok/s.
- Trap 09: Dexter2 DeepSeek-v4-Flash runtime ABLATE shows identical weights + unchanged image digest can still change behavior when model code is bind-mounted at runtime (8/8→0/8 refusals thinking-off; 7/8→0/8 thinking-on; no obvious smoke/perf regression).
- Adds a mining note with full claim boundaries and private evidence pointers.

No new public trap count. Trap 14 explicitly remains separate because the Dexter2 experiment did not change/re-upload weights.