### PR TITLE
Upstream: promote SGLang v0.5.18 source-level reports

### DIFF
--- a/mining/2026-08-25-sglang-upstream-promotion.md
+++ b/mining/2026-08-25-sglang-upstream-promotion.md
@@ -1,0 +1,39 @@
+# SGLang v0.5.18 upstream promotion pass
+
+**Date:** 2026-08-25
+
+This is the promotion record for the `UPSTREAM_READY` subset of
+[`2026-08-25-sglang-veloGB10-glm52-public-source-harvest.md`](2026-08-25-sglang-veloGB10-glm52-public-source-harvest.md).
+
+**Canonical trap count impact: 0.** These are `upstream/` entries only. Nobody here has reproduced them, they do not enter Core, they do not count toward Doctor coverage, and they do not increment the 133-entry measured registry.
+
+## Promotion map
+
+| Harvest | Upstream entry | Primary source | Disposition |
+|---|---|---|---|
+| H25-01 | U27 | SGLang #34189 | promoted, distinct hard-coded DSV4 write-pad mechanism |
+| H25-02 | U28 | SGLang #34184 | promoted, distinct stale captured track-row/prefix-cache mechanism |
+| H25-03 | U29 | SGLang #33517 | promoted, distinct virtual-vs-physical KV-id mechanism |
+| H25-04 | U30 | SGLang #33974 | promoted, recycled partial-page tail mechanism |
+| H25-05 | U31 | SGLang #33974 | promoted separately, int32 slot-stride wrap mechanism |
+| H25-06 | U32 | SGLang #33758 | promoted, stop/EOS vs length ordering under multi-token accept |
+| H25-07 | U33 | SGLang #34524 | promoted, absent checkpoint metadata + runtime default drift |
+| H25-08 | U34 | SGLang #33912 | promoted, DCP replication omitted from exact draft-KV accounting |
+| H25-09 | U35 | SGLang #34372 | promoted, resolvable but incompatible Blackwell FA4 dependency pair |
+
+## Duplicate boundaries checked
+
+The candidates were compared against the current registry and upstream tier before promotion. Adjacent material remains adjacent rather than being rewritten:
+
+- Trap 122 is a Qwen3.8/vLLM FULL-vs-PIECEWISE graph corruption mechanism; U27 and U28 are different SGLang state-write/captured-track mechanisms.
+- Trap 28 and U16 cover speculative failures at concurrency/batch boundaries without these source-level mechanisms.
+- Existing prefix-cache and memory traps do not encode U28's stale `mamba_track_*` destination rows, U30's recycled page-tail exposure, U31's int32 stride wrap, or U34's DCP draft-budget omission.
+- Existing versioning/provenance material does not encode U33's missing `is_causal` semantic-default change or U35's dependency pair that resolves successfully but fails Blackwell compilation.
+
+This pass therefore promotes the source-level mechanisms without changing or inflating the measured registry.
+
+## Not promoted from the same harvest
+
+The remaining SGLang release notes and the `glm52-spark-kit` / `veloGB10` findings stay in their original `EXISTING_EXTENSION`, `LEAD_QUEUE`, `CONTROL_ONLY`, or `NOT_TRAP` dispositions. Community-repo findings are not silently upgraded to upstream entries just because their engineering detail is strong.
+
+No third-party issue was created and no upstream project was contacted during this pass.

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -67,6 +67,15 @@ were closed by a staleness bot while a maintainer reproduction and a
 | [U24, stale DSpark slot ids can kill the engine at request condensation](U24-dspark-stale-slot-id-after-request-condensation.md) | vLLM DSpark | maintainer confirmed | closed, fixed |
 | [U25, naive uniqueness metrics can call a reasoning loop fresh text](U25-loop-detector-block-uniqueness-misses-templated-loops.md) | evaluation / reasoning traces | maintainer confirmed | closed, fixed |
 | [U26, EngineDead can still exit the serving container with code 0](U26-vllm-enginedead-container-exits-zero-and-stays-down.md) | vLLM / Docker | maintainer confirmed | closed, fixed |
+| [U27, draft counts above four can leave stale DSV4 compressed state](U27-sglang-dsv4-spec-draft-over4-stale-compress-state.md) | SGLang / DeepSeek V4 | maintainer confirmed | closed, fixed |
+| [U28, a prefix-cache hit can restore another request's conv state](U28-sglang-prefill-graph-stale-track-prefix-cache.md) | SGLang / hybrid SWA-Mamba | maintainer confirmed | closed, fixed |
+| [U29, unified memory + Triton + deterministic inference can mix KV id spaces](U29-sglang-unified-triton-deterministic-virtual-physical-kv.md) | SGLang | maintainer confirmed | closed, fixed |
+| [U30, recycled unified-memory page tails can leak historical bytes](U30-sglang-unified-page-recycle-stale-tail.md) | SGLang / DSPARK | maintainer confirmed | closed, fixed |
+| [U31, 32-bit slot-stride multiplication can wrap recurrent state addresses](U31-sglang-int32-slot-stride-wrap-recurrent-state.md) | SGLang / DSPARK | maintainer confirmed | closed, fixed |
+| [U32, a speculative accept run can leak tokens after EOS at the length cap](U32-sglang-spec-stop-eos-crosses-length-cap.md) | SGLang / speculative decode | maintainer confirmed | closed, fixed |
+| [U33, missing DFlash causality metadata can change semantics after an update](U33-sglang-dflash-missing-is-causal-default-drift.md) | SGLang / DFlash | maintainer confirmed | closed, fixed |
+| [U34, DFlash draft-KV budgeting can undercount by the DCP factor](U34-sglang-dflash-dcp-draft-kv-budget-undercount.md) | SGLang / DFlash / DCP | maintainer confirmed | closed, fixed |
+| [U35, a resolvable dependency set can still make FA4 fail on Blackwell](U35-sglang-fa4-blackwell-resolved-deps-still-fail-compile.md) | SGLang / FA4 / Blackwell | maintainer confirmed | closed, fixed |
 
 ## Where these came from, and what did not survive
 
@@ -95,6 +104,14 @@ extend existing canonical traps 01 and 07; the unresolved CUBLAS engine-death
 root cause, non-default-port health-check bug, fragmented-loop limitation and
 other secondary leads remain in
 [`mining/2026-08-21-tonyd2wild-deepseek-v4-community-harvest.md`](../mining/2026-08-21-tonyd2wild-deepseek-v4-community-harvest.md).
+
+U27-U35 came from the 2026-08-25 SGLang v0.5.18 source-mining pass. Each entry
+is backed by a merged SGLang PR with a concrete source-level mechanism, but none
+has been reproduced by this registry. The exact promotion map and duplicate
+boundaries are recorded in
+[`mining/2026-08-25-sglang-upstream-promotion.md`](../mining/2026-08-25-sglang-upstream-promotion.md).
+The community `glm52-spark-kit` and `veloGB10` findings from the same harvest
+remain in the lead/adjudication path rather than being silently upgraded.
 
 The procedural rule from the first pass still holds: **the mining summary is a
 lead, not the source.** Read the current tracker thread, preserve corrections

--- a/upstream/U27-sglang-dsv4-spec-draft-over4-stale-compress-state.md
+++ b/upstream/U27-sglang-dsv4-spec-draft-over4-stale-compress-state.md
@@ -1,0 +1,29 @@
+# U27: speculative draft counts above four can silently leave stale DSV4 compressed state
+
+**Reported by @hnyls2002.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #34189 is merged.
+
+**Primary source.** [SGLang PR #34189](https://github.com/sgl-project/sglang/pull/34189), read on 2026-08-25.
+
+**Symptom.** DeepSeek-V4 speculative serving can stay alive with no assertion, illegal access or NaN while the compressed-state ring contains stale positions once the speculative draft count exceeds four. Ordinary end-to-end quality runs may not reliably expose it because the stale read depends on acceptance length, sequence position and compression alignment.
+
+**Mechanism.** The compressed-state write planner used a hard-coded speculative pad of four. With `--speculative-num-draft-tokens > 4`, a verify batch could under-write positions that a later compression still needed. The host planner also omitted the pad term, so CPU and GPU planner paths could disagree. The merged fix derives the pad from ring capacity and rejects unsupported draft counts at startup instead of permitting silent under-write.
+
+**What we have not done.** We have not reproduced the pre-fix SGLang/DeepSeek-V4 path on Blackwellboy infrastructure or established which released builds besides the source revision carry the defect.
+
+## If you have this stack
+
+Pin the pre-fix build from the PR, use DeepSeek-V4 speculative decoding, and sweep draft counts across the old boundary while checking ring residency and CPU/GPU planner agreement across compression residues. Keep a fixed-build control with the same model and settings.
+
+**CONFIRM.** Draft count 5 or higher causes the pre-fix planner to omit committed tail positions or disagree between planner paths, while the fixed build covers the full committed range.
+
+**REFUTE.** The pinned pre-fix planner already retains every committed speculative position and CPU/GPU plans agree for the reported draft counts and residues.
+
+## Attribution
+
+Reported and fixed upstream by @hnyls2002 in SGLang PR #34189. The registry has not independently reproduced the measurement.

--- a/upstream/U28-sglang-prefill-graph-stale-track-prefix-cache.md
+++ b/upstream/U28-sglang-prefill-graph-stale-track-prefix-cache.md
@@ -1,0 +1,29 @@
+# U28: a prefix-cache hit can restore another request's conv state under the prefill graph
+
+**Reported by @ispobock.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #34184 is merged.
+
+**Primary source.** [SGLang PR #34184](https://github.com/sgl-project/sglang/pull/34184), read on 2026-08-25.
+
+**Symptom.** A hybrid-SWA/Mamba request can decode from a convolution checkpoint it never produced. The request may remain wrong for its whole generation. The failure requires the prefill CUDA graph, chunked prefill, concurrency and a prefix-cache hit; disabling the prefill graph removes it.
+
+**Mechanism.** Captured prefill replay read stale `mamba_track_mask` and `mamba_track_indices` rows left by a previous replay. The current request's window could therefore be scattered into an earlier request's checkpoint, and a later prefix-cache restore loaded that wrong state. The merged fix clears those track rows with the other captured-tail buffers.
+
+**What we have not done.** We have not reproduced the affected hybrid-SWA/Mamba graph/cache path on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build, enable the prefill CUDA graph and prefix cache, use chunked prefill with concurrent prompts, and compare cache-hit generations/logprobs and restored conv state with an eager or flushed-cache control.
+
+**CONFIRM.** The pre-fix graph path writes or restores a checkpoint using stale track destinations and diverges from the flushed/eager control, while the fixed build does not.
+
+**REFUTE.** The pinned pre-fix graph path is state- and output-equivalent to the flushed/eager control across the reported cache-hit/concurrency shape.
+
+## Attribution
+
+Reported and fixed upstream by @ispobock in SGLang PR #34184. The registry has not independently reproduced the measurement.

--- a/upstream/U29-sglang-unified-triton-deterministic-virtual-physical-kv.md
+++ b/upstream/U29-sglang-unified-triton-deterministic-virtual-physical-kv.md
@@ -1,0 +1,29 @@
+# U29: unified memory + Triton + deterministic inference can mix virtual and physical KV ids
+
+**Reported by @ch-wan.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #33517 is merged.
+
+**Primary source.** [SGLang PR #33517](https://github.com/sgl-project/sglang/pull/33517), read on 2026-08-25.
+
+**Symptom.** `--enable-unified-memory` plus Triton attention plus deterministic inference can produce garbage/NaN logits. Any two of the three conditions are clean. With async assertions armed the failure aborts; without them the upstream report says the run can complete locally, making the corruption much easier to miss.
+
+**Mechanism.** The deterministic one-stage Triton extend kernel read the prefix from translated physical KV locations but the just-written extend half from untranslated virtual locations. The merged fix reuses the already-computed physical translation for the extend read.
+
+**What we have not done.** We have not reproduced this three-way SGLang configuration on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build and compare unified vs static pools with deterministic inference and Triton pinned. Then remove one condition at a time. Capture token ids and output logprobs, not only HTTP success.
+
+**CONFIRM.** The pre-fix three-way configuration diverges or produces NaN/garbage while the static-pool control and the one-condition-removed controls remain clean; the fixed build restores parity.
+
+**REFUTE.** The pinned pre-fix unified path is token/logprob-equivalent to the static-pool path under all three reported conditions.
+
+## Attribution
+
+Reported and fixed upstream by @ch-wan in SGLang PR #33517. The registry has not independently reproduced the measurement.

--- a/upstream/U30-sglang-unified-page-recycle-stale-tail.md
+++ b/upstream/U30-sglang-unified-page-recycle-stale-tail.md
@@ -1,0 +1,29 @@
+# U30: recycled unified-memory page tails can leak historical bytes into speculative attention
+
+**Reported by @ch-wan.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #33974 is merged.
+
+**Primary source.** [SGLang PR #33974](https://github.com/sgl-project/sglang/pull/33974), read on 2026-08-25.
+
+**Symptom.** Unified-memory + DSPARK speculative serving can show fake acceptance, invalid accuracy, NaNs or load-dependent corruption. Poisoning the pool makes the class deterministic; ordinary clean boots can hide it.
+
+**Mechanism.** Recycled partial pages can expose historical bytes in unused tail rows. The affected MLA path reads whole page envelopes and masks rows beyond `seq_len` arithmetically, which is not NaN-safe. Speculative verification repeatedly lands on fresh tail pages and amplifies exposure. The merged fix zeroes page envelopes when the allocator hands them out.
+
+**What we have not done.** We have not reproduced the affected unified-memory/DSPARK allocation path on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build, poison or otherwise mark page envelopes, recycle pages under unified memory with DSPARK, and compare with a zero-on-handout or static-pool control. Record acceptance and accuracy as well as NaNs/crashes.
+
+**CONFIRM.** Recycled tail contents influence the pre-fix speculative/attention result or create fake acceptance, while zero-on-handout/static controls remain clean.
+
+**REFUTE.** The pinned pre-fix kernel never consumes stale partial-page tail contents and poisoned vs clean/recycled controls remain equivalent.
+
+## Attribution
+
+Reported and fixed upstream by @ch-wan in SGLang PR #33974. This is one of two independent root causes in that PR; U31 records the separate slot-stride overflow. The registry has not independently reproduced the measurement.

--- a/upstream/U31-sglang-int32-slot-stride-wrap-recurrent-state.md
+++ b/upstream/U31-sglang-int32-slot-stride-wrap-recurrent-state.md
@@ -1,0 +1,29 @@
+# U31: 32-bit slot-stride multiplication can wrap into another request's recurrent state
+
+**Reported by @ch-wan.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #33974 is merged.
+
+**Primary source.** [SGLang PR #33974](https://github.com/sgl-project/sglang/pull/33974), read on 2026-08-25.
+
+**Symptom.** A clean boot can work at low slot ids and later show silent state divergence, fake speculative acceptance or an illegal access as slot ids grow. The load-dependent threshold makes cold or low-concurrency validation look healthy.
+
+**Mechanism.** Unified-memory conv/SSM state views carry very large slot strides. Each stride can fit in int32 while `slot * stride` does not. The affected CuTe path folded the multiplication into 32-bit arithmetic, so sufficiently large slot ids wrapped into another slot's bytes or outside the allocation. The merged fix promotes slot ids before the stride multiplication.
+
+**What we have not done.** We have not reproduced this high-slot-id SGLang kernel path on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build and replay the affected state kernel over increasing slot ids using faithful unified-memory strides, with an int64-addressing/static-layout control. Include low slots that should pass and slots above the reported wrap boundary.
+
+**CONFIRM.** The pre-fix path is correct at low slot ids but diverges or faults at higher ids, while the int64/static control remains correct.
+
+**REFUTE.** Pre-fix address arithmetic remains exact across the reported slot-id/stride range and matches the control.
+
+## Attribution
+
+Reported and fixed upstream by @ch-wan in SGLang PR #33974. This is separate from U30's recycled-page-tail mechanism. The registry has not independently reproduced the measurement.

--- a/upstream/U32-sglang-spec-stop-eos-crosses-length-cap.md
+++ b/upstream/U32-sglang-spec-stop-eos-crosses-length-cap.md
@@ -1,0 +1,29 @@
+# U32: a speculative accept run can leak tokens after EOS when it also crosses the length cap
+
+**Reported by @842974287.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #33758 is merged.
+
+**Primary source.** [SGLang PR #33758](https://github.com/sgl-project/sglang/pull/33758), read on 2026-08-25.
+
+**Symptom.** One speculative multi-token commit can contain an EOS/stop and cross `max_new_tokens` in the same step, producing emitted output shaped like `[..., <eos>, <junk>]` instead of trimming at the stop.
+
+**Mechanism.** Finish-state handling checked the length cap before stop strings and stop tokens. A multi-token speculative accept therefore could be classified as a length finish before the in-budget stop was processed, preserving over-accepted tokens after the stop. The merged fix gives in-budget stop/EOS precedence and caps stops that occur beyond the budget.
+
+**What we have not done.** We have not reproduced the affected SGLang speculative finish-state path on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build and construct a speculative step whose accepted run contains EOS or a stop string before the length cap plus at least one accepted token after it. Compare emitted ids and finish reason with the fixed build and a non-speculative control.
+
+**CONFIRM.** The pre-fix request emits a token after an in-budget stop/EOS or reports length where the fixed build trims at the stop.
+
+**REFUTE.** The pinned pre-fix path already trims at the in-budget stop and never emits accepted tokens after it.
+
+## Attribution
+
+Reported and fixed upstream by @842974287 in SGLang PR #33758. The registry has not independently reproduced the measurement.

--- a/upstream/U33-sglang-dflash-missing-is-causal-default-drift.md
+++ b/upstream/U33-sglang-dflash-missing-is-causal-default-drift.md
@@ -1,0 +1,29 @@
+# U33: missing DFlash causality metadata can change draft semantics after a runtime update
+
+**Reported by @mmangkad.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The compatibility fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #34524 is merged.
+
+**Primary source.** [SGLang PR #34524](https://github.com/sgl-project/sglang/pull/34524), read on 2026-08-25.
+
+**Symptom.** An unchanged DFlash checkpoint can lose speculative acceptance after a runtime update. In the upstream Gemma-4 case, average accept length moved from about 5.62 to about 5.27-5.30 even though the checkpoint itself did not change.
+
+**Mechanism.** The checkpoint did not declare `is_causal`. A runtime change altered the default interpretation of DFlash sliding-attention layers, changing their semantics without a checkpoint edit. The merged fix restores historical layer-specific defaults when metadata is absent while continuing to honor explicit `is_causal=True/False`.
+
+**What we have not done.** We have not reproduced the affected checkpoint/runtime pair on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the affected checkpoint and compare the pre-regression, regressed and fixed runtime behavior. Inspect the resolved attention type for every DFlash draft layer and record acceptance on the same prompts.
+
+**CONFIRM.** The checkpoint omits `is_causal`, the regressed runtime resolves different layer semantics than the historical/fixed control, and acceptance moves with that semantic change.
+
+**REFUTE.** The allegedly affected runtime resolves the same attention semantics as the historical control and the acceptance difference persists for another reason.
+
+## Attribution
+
+Reported and fixed upstream by @mmangkad in SGLang PR #34524. The registry has not independently reproduced the measurement.

--- a/upstream/U34-sglang-dflash-dcp-draft-kv-budget-undercount.md
+++ b/upstream/U34-sglang-dflash-dcp-draft-kv-budget-undercount.md
@@ -1,0 +1,29 @@
+# U34: DFlash draft-KV budgeting can undercount memory by the DCP replication factor
+
+**Reported by @milesial.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #33912 is merged.
+
+**Primary source.** [SGLang PR #33912](https://github.com/sgl-project/sglang/pull/33912), read on 2026-08-25.
+
+**Symptom.** Memory/capacity planning for a DFlash-family speculative draft can look safe under DCP while the real draft pool consumes more space than the exact geometry calculation reports.
+
+**Mechanism.** The exact draft-geometry path charged one draft row per target token, but under DCP the draft pool spans the widened virtual location space and the draft term is replicated by `dcp_size`. The fallback path already accounted for that factor; the exact path did not. The merged fix multiplies the draft cell cost by the resolved DCP size.
+
+**What we have not done.** We have not reproduced the affected SGLang DCP/DFlash allocation path on Blackwellboy infrastructure.
+
+## If you have this stack
+
+Pin the pre-fix build and compare reported bytes-per-token/cell-size accounting at DCP1 and DCP>1 with the actual draft-pool geometry and allocation. Keep model, draft geometry and target KV shape fixed.
+
+**CONFIRM.** The pre-fix exact-geometry path fails to scale the draft term with DCP while actual allocation/fallback accounting does; the fixed build restores agreement.
+
+**REFUTE.** The pinned pre-fix exact path already applies the DCP replication factor and matches actual allocation.
+
+## Attribution
+
+Reported and fixed upstream by @milesial in SGLang PR #33912. The registry has not independently reproduced the measurement.

--- a/upstream/U35-sglang-fa4-blackwell-resolved-deps-still-fail-compile.md
+++ b/upstream/U35-sglang-fa4-blackwell-resolved-deps-still-fail-compile.md
@@ -1,0 +1,29 @@
+# U35: a dependency set can resolve cleanly and still make FA4 fail to compile on Blackwell
+
+**Reported by @mmangkad.**
+
+**Status: upstream-reported.** Nobody here has reproduced this.
+
+**Maintainer engagement: maintainer confirmed.** The dependency fix was reviewed and merged into SGLang.
+
+**Issue state: closed, fixed.** SGLang PR #34372 is merged.
+
+**Primary source.** [SGLang PR #34372](https://github.com/sgl-project/sglang/pull/34372), read on 2026-08-25.
+
+**Symptom.** SGLang can resolve and install a valid-looking dependency combination, then fail while compiling an FA4 kernel on Blackwell during startup.
+
+**Mechanism.** `quack-kernels==0.6.3` could resolve with `nvidia-cutlass-dsl==4.6.0`, but that pair exposed a CuTeDSL branch-scope/type-join compiler bug after Quack's AST rewrite. SGLang fixed the path by pinning a matched Quack/CuTeDSL pair containing the compiler fix.
+
+**What we have not done.** We have not reproduced this dependency/compiler pair on Blackwellboy infrastructure and do not claim every FA4 startup failure has this cause.
+
+## If you have this stack
+
+Pin the affected SGLang dependency pair on Blackwell and compile the same FA4 relative-bias path, then repeat with the fixed matched versions. Record the exact resolved package versions rather than only the SGLang tag.
+
+**CONFIRM.** The old dependency pair resolves successfully but reproduces the reported FA4 compile error, while the fixed matched pair compiles the same path.
+
+**REFUTE.** The pinned allegedly affected pair compiles the target FA4 kernel successfully, or the failure persists identically on the fixed pair.
+
+## Attribution
+
+Reported and fixed upstream by @mmangkad in SGLang PR #34372. The registry has not independently reproduced the measurement.


### PR DESCRIPTION
Promotes the nine `UPSTREAM_READY` SGLang candidates from the 2026-08-25 public-source harvest into the non-canonical `upstream/` tier as U27-U35.

Boundaries preserved:
- canonical trap count remains 133
- none of these enter Core or Doctor coverage
- no first-party reproduction is claimed
- every entry links the primary merged SGLang PR, credits the reporter, records issue state/maintainer engagement, and includes CONFIRM/REFUTE criteria
- U30 and U31 stay separate because SGLang #33974 fixed two independent corruption mechanisms
- a promotion map records duplicate boundaries against existing Minefield material

No third-party issue created and no upstream project contacted.