### PR TITLE
Doctor: handle null default generation params

### DIFF
--- a/doctor/minefield_doctor.py
+++ b/doctor/minefield_doctor.py
@@ -54,7 +54,7 @@ REG = "https://github.com/Blackwellboy/model-serving-minefield/blob/main/traps"
 # asserts this constant still matches the tree, so it cannot drift silently.
 # Any PR that lands new trap files fails that test until this is bumped and the
 # coverage sentences in README.md and doctor/README.md are updated with it.
-REGISTRY_TRAP_COUNT = 137
+REGISTRY_TRAP_COUNT = 135
 
 TRAP_PATHS = {
     "01": "reasoning/01-reasoning-field-two-names.md",
@@ -1778,14 +1778,14 @@ def hf_resolve_revision(repo, revision):
 def check_configs(doc, hf_repo, hf_revision="main"):
     """Traps 21 (generation_config missing), 17 (defaults vs card), 10 (quant)."""
     props = doc.evidence.get("props")
+    eff = None #always none unless props and p
     if props:
         p = (props.get("default_generation_settings") or {}).get("params", {})
-        eff = {k: round(v, 3) if isinstance(v, float) else v
-               for k, v in p.items()
-               if k in ("temperature", "top_k", "top_p", "min_p", "presence_penalty")}
-        doc.evidence["server_defaults"] = eff
-    else:
-        eff = None
+        if p is not None:
+            eff = {k: round(v, 3) if isinstance(v, float) else v
+                   for k, v in p.items()
+                   if k in ("temperature", "top_k", "top_p", "min_p", "presence_penalty")}
+            doc.evidence["server_defaults"] = eff
     if not hf_repo:
         doc.skip(["21", "17", "10"], "generation_config / card-sampling / quant "
                  "scheme checks",

--- a/doctor/tests/test_null_generation_params.py
+++ b/doctor/tests/test_null_generation_params.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Regression for nullable llama.cpp generation params reported by /props."""
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_doctor():
+    path = REPO_ROOT / "doctor" / "minefield_doctor.py"
+    spec = importlib.util.spec_from_file_location("minefield_doctor_null_params", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class NullGenerationParamsTest(unittest.TestCase):
+    def test_null_default_generation_params_do_not_crash(self):
+        md = _load_doctor()
+        doc = md.Doc()
+        doc.evidence["props"] = {
+            "default_generation_settings": {"params": None}
+        }
+        md.check_configs(doc, None)
+        self.assertNotIn("server_defaults", doc.evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/minefield/data/minefield_doctor.py
+++ b/minefield/data/minefield_doctor.py
@@ -54,7 +54,7 @@ REG = "https://github.com/Blackwellboy/model-serving-minefield/blob/main/traps"
 # asserts this constant still matches the tree, so it cannot drift silently.
 # Any PR that lands new trap files fails that test until this is bumped and the
 # coverage sentences in README.md and doctor/README.md are updated with it.
-REGISTRY_TRAP_COUNT = 137
+REGISTRY_TRAP_COUNT = 135
 
 TRAP_PATHS = {
     "01": "reasoning/01-reasoning-field-two-names.md",
@@ -1778,14 +1778,14 @@ def hf_resolve_revision(repo, revision):
 def check_configs(doc, hf_repo, hf_revision="main"):
     """Traps 21 (generation_config missing), 17 (defaults vs card), 10 (quant)."""
     props = doc.evidence.get("props")
+    eff = None #always none unless props and p
     if props:
         p = (props.get("default_generation_settings") or {}).get("params", {})
-        eff = {k: round(v, 3) if isinstance(v, float) else v
-               for k, v in p.items()
-               if k in ("temperature", "top_k", "top_p", "min_p", "presence_penalty")}
-        doc.evidence["server_defaults"] = eff
-    else:
-        eff = None
+        if p is not None:
+            eff = {k: round(v, 3) if isinstance(v, float) else v
+                   for k, v in p.items()
+                   if k in ("temperature", "top_k", "top_p", "min_p", "presence_penalty")}
+            doc.evidence["server_defaults"] = eff
     if not hf_repo:
         doc.skip(["21", "17", "10"], "generation_config / card-sampling / quant "
                  "scheme checks",


### PR DESCRIPTION
Superseded by clean first-party PR #103. #96 accidentally regressed the canonical Doctor registry count from 137 to 135. PR #103 preserves the 137-trap main state, carries @emmybearretro's substantive nullable-params fix, and retains the regression test. Do not merge this branch.