### PR TITLE
Governance: preregister issue 105 DFlash draft-budget failure

### DIFF
--- a/registry/OPEN_TRAP_ISSUES.md
+++ b/registry/OPEN_TRAP_ISSUES.md
@@ -71,6 +71,13 @@ Coverage snapshot: the doctor implements checks for **19 of 137** entries.  118 
 - **REFUTE.** The pinned Docker version refuses the absent source without creating it, creates a source of the expected type, the late model/checkpoint failure cannot be attributed to the fabricated mount source, or the deleted-file restart does not produce the reported directory/type mismatch under the declared mount syntax.
 - **Boundary.** Keep this separate from canonical trap 127 unless adjudication proves the same mechanism. Trap 127 is whole-file package shadowing plus image drift/unattended update; Q100 is host-source absence/deletion changing mount-source type. Scope any promotion to the tested Docker bind-mount syntax/version rather than claiming every Docker version or mount API behaves identically.
 
+### Q105. DFlash draft budget 2 fails during decode CUDA-graph capture on the reported SGLang path
+
+- **Public issue.** https://github.com/Blackwellboy/model-serving-minefield/issues/105
+- **CONFIRM.** On the pinned SGLang DFlash2/NVFP4 lane, hold image, target, drafter, block size and all other serve flags fixed while sweeping `--speculative-num-draft-tokens` across at least 2, 4, 6 and 8. Treat startup as the measured outcome before any benchmark request. Confirm budget 2 deterministically fails during the draft worker's decode CUDA-graph capture with the reported non-contiguous FP4-quantization path, while the 4/6/8 controls reach health under the same launch conditions. Preserve the full traceback and resolve whether the tensor-contiguity difference is actually caused by depth 2 rather than merely correlated with it.
+- **REFUTE.** Budget 2 reaches health under the pinned build, one or more matched 4/6/8 controls fail with the same signature, the failure occurs outside the draft decode graph/FP4 path, or source-level inspection/reproduction shows an independent configuration or checkpoint defect explains the contiguity failure.
+- **Boundary.** Keep the observed startup cliff separate from generic high-depth quality/performance or OOM traps. Do not promote the issue's inferred tensor-shape mechanism as proven until source inspection or a bounded reproduction identifies why depth 2 changes contiguity. A failed-to-start arm is an explicit failure outcome, not a zero-score or missing benchmark cell.
+
 ## Privacy rule
 
 Raw candidate research and unpublished evidence are not a public-repository surface. Public promotion starts from a deliberately scrubbed/adjudicated change, not by copying a private research directory into this repository.


### PR DESCRIPTION
Adds public CONFIRM/REFUTE criteria for newly opened `[trap]` issue #105 before adjudication, restoring the live open-trap queue invariant.

Scope is deliberately narrow: this records the reported SGLang DFlash2/NVFP4 startup cliff at `--speculative-num-draft-tokens 2` and keeps the tensor-contiguity mechanism explicitly unproven until source inspection or bounded reproduction resolves causality. A failed-to-start arm is preserved as a failure outcome, not converted to a benchmark zero or missing cell.

Governance only: no canonical trap number, no raw/private evidence, no GPU reproduction, and no private mining material.